### PR TITLE
correct apt install command

### DIFF
--- a/installation/ubuntu.rst
+++ b/installation/ubuntu.rst
@@ -46,7 +46,7 @@ you which package to install:
 
 Install them either with your favorite package manager or the command ::
 
-    sudo apt -install acpi-call-dkms tp-smapi-dkms
+    sudo apt install acpi-call-dkms tp-smapi-dkms
 
 omitting the one not required by your hardware.
 


### PR DESCRIPTION
Correct installation command via apt is `sudo apt install`, not `sudo apt -install`