### PR TITLE
The acpi_call-kmp-default package should be additionally installed on Tumbleweed

### DIFF
--- a/installation/opensuse.rst
+++ b/installation/opensuse.rst
@@ -32,6 +32,8 @@ guide you which package to install:
 * **acpi_call** – optional – External kernel module providing battery
   recalibration for newer ThinkPads (X220/T420 and later)
   - `Download acpi_call <https://software.opensuse.org/package/acpi_call>`_
+* **acpi_call-kmp-default** - optional - Tumbleweed only; should be installed together with the acpi_call package 
+  - `Download acpi_call-kmp-default <https://software.opensuse.org/package/acpi_call-kmp-default>`_
 * **tp_smapi_kmp** – optional – External kernel module providing battery charge
   thresholds, recalibration and specific :command:`tlp-stat -b` output
   for older ThinkPads


### PR DESCRIPTION
Actually, I don't know how to correctly state this in the documentation, but for battery recalibration to work on openSUSE Tumbleweed, the acpi_call-kmp-default package should be installed together with the acpi_call package. The acpi_call-kmp-default package installs the kernel module, while the acpi_call installs the files required to automatically load this kernel module at boot time. This is for Tumbleweed only (acpi_call-kmp-default package isn't available for Leap).

See https://github.com/linrunner/TLP/issues/571#issuecomment-920692069