### PR TITLE
Fixed incorrect highlighting of a line in paragraph 5 of optimizing.rst

### DIFF
--- a/support/optimizing.rst
+++ b/support/optimizing.rst
@@ -73,7 +73,7 @@ Improve performance on AC power
 5. Enable the :ref:`platform profile <set-platform-profile>` `performance`:
 
 .. code-block::
-    :emphasize-lines: 2
+    :emphasize-lines: 1
 
     PLATFORM_PROFILE_ON_AC=performance
     PLATFORM_PROFILE_ON_BAT=balanced


### PR DESCRIPTION
In paragraph 5, the line ```"PLATFORM_PROFILE_ON_BAT=balanced"``` was incorrectly highlighted when ```"PLATFORM_PROFILE_ON_AC=performance"``` should be